### PR TITLE
chore: remove leftover comment

### DIFF
--- a/inventory_backend/dashboard/routes.py
+++ b/inventory_backend/dashboard/routes.py
@@ -197,7 +197,7 @@ def get_unit_details(serial_number: str):
             "received_date": str(row.received_date),
             "sold": row.sold,
             "is_damaged": row.is_damaged,
-            "po_number": row.po_number  # <-- add this line
+            "po_number": row.po_number
         }
 
 @router.get("/insights/monthly-report")


### PR DESCRIPTION
## Summary
- remove stale comment from unit details return payload

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688befb592908326b8f4e8c42390610a